### PR TITLE
Close the connection instead of destoying it

### DIFF
--- a/lib/pjlink.js
+++ b/lib/pjlink.js
@@ -229,7 +229,7 @@ PJLink.prototype._resetConnection = function(){
 		this._connection.removeListener('error', this._errorCB);
 		this._connection.removeListener('close', this._closeCB);
 		this._connection.removeListener('timeout', this._timeoutCB);
-		this._connection.destroy();
+		this._connection.close();
 	}
 
 	//reset the connection etc


### PR DESCRIPTION
The socket was closed using destroy() which meant that in some cases the projectors would leave the socket open and prevent further connections.  Using socket.close seems to solve this issue.
Thanks !