### PR TITLE
Fix error, use end() instead of close()

### DIFF
--- a/lib/pjlink.js
+++ b/lib/pjlink.js
@@ -229,7 +229,7 @@ PJLink.prototype._resetConnection = function(){
 		this._connection.removeListener('error', this._errorCB);
 		this._connection.removeListener('close', this._closeCB);
 		this._connection.removeListener('timeout', this._timeoutCB);
-		this._connection.close();
+		this._connection.end();
 	}
 
 	//reset the connection etc


### PR DESCRIPTION
Terribly sorry, did that last PR too quickly, should be using socket.end() rather than close().

Thanks !