### PR TITLE
Convert the parsed command to uppercase

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -53,7 +53,7 @@ Response.parse = function(data){
 
 	var cmd, args, err;
 
-	var cmd = data.substr(0,6)//header + command;
+	var cmd = data.substr(0,6).toUpperCase();//header + command;
 	data = data.substr(7);//skip to the data
 
 	//the data should now contain an error if it is there


### PR DESCRIPTION
Some projectors (like my Optoma) send `pjlink 0` during handshake