### PR TITLE
Allow projectors to return lowercase responses

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -27,6 +27,8 @@ Command.prototype.handleResponse = function(resp){
 	//no callback, so return
 	if(!this.cb) return;
 
+	resp = resp.ToUpperCase();
+	
 	if(resp.isError()){
 		this.cb(resp.getError());
 		return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pjlink",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"dependencies": {
 		"extend": "~3.0.0"
 	},


### PR DESCRIPTION
My Viewsonic Projector returns responses in lowercase, this currently results in a command reply mismatch.