### PR TITLE
Fix error in “setInput“ command (typo)

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -108,7 +108,7 @@ Command.InputCommand = function(){
 			input.channel = parseInt(args[0].substr(1,1));
 		}else if(typeof args[0]=='number' && args[0]>=10){ //number code
 			input.channel = args[0]%10;
-			input.source = (args[0]-inout.channel)/10;
+			input.source = (args[0]-input.channel)/10;
 		}else{
 			input.source = args.shift();
 			if(args.length) input.channel = args.shift();


### PR DESCRIPTION
Fixes „inout is not defined“ error when trying to change the projector‘s input source.